### PR TITLE
Add missing Category parameters that cause build errors on Linux

### DIFF
--- a/Source/URoboSim/Public/RRobot.h
+++ b/Source/URoboSim/Public/RRobot.h
@@ -50,7 +50,7 @@ public:
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Substepping Parameters")
 	float StartVelocity;
 
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SubsteppingParameters")
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Substepping Parameters")
 	float KSpring;
 
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Substepping Parameters")
@@ -179,15 +179,15 @@ public:
 	void ParseURDF();
 
 
-	UPROPERTY(EditAnywhere, Export)
+	UPROPERTY(EditAnywhere, Export, Category="Robot")
 	float GlobalVarA;
 
 	// Copy the XML URDF Code
-	UPROPERTY(EditAnywhere, Export)
+	UPROPERTY(EditAnywhere, Export, Category="Robot")
 	FString XmlUrdf;
 
 	// The material used for all robot links
-	UPROPERTY(EditAnywhere)
+	UPROPERTY(EditAnywhere, Category="Robot")
 	UMaterial* BasicMaterial;
 
 	// Rotates the joint to the targeted rotation

--- a/Source/URoboSim/Public/RTestRobotMotors.h
+++ b/Source/URoboSim/Public/RTestRobotMotors.h
@@ -22,11 +22,11 @@ class UROBOSIM_API ARTestRobotMotors : public ARRobot
 	virtual void Tick(float DeltaSeconds) override;
 
 	// Target rotation for motor of second_to_third_joint
-	UPROPERTY(EditAnywhere)
+	UPROPERTY(EditAnywhere, Category="Robot Motors")
 	FRotator TargetRotation;
 
 	// Target location for motor of first_to_second_joint
-	UPROPERTY(EditAnywhere)
+	UPROPERTY(EditAnywhere, Category="Robot Motors")
 	FVector TargetLocation;
 
 };

--- a/Source/URoboSim/Public/RURDFData.h
+++ b/Source/URoboSim/Public/RURDFData.h
@@ -18,7 +18,7 @@ public:
 #if WITH_EDITOR
 
 	/** Saves the XML */
-	UPROPERTY(VisibleAnywhere, AssetRegistrySearchable)
+	UPROPERTY(VisibleAnywhere, AssetRegistrySearchable, Category = ImportSettings)
 	FString Xml;
 
 	/** For Drag and Drop reimport. */


### PR DESCRIPTION
Ubuntu 16.04.1
Unreal Engine 4.19.1

Following errors occur while compiling the master branch:
```
LogCompile: Error: An explicit Category specifier is required for any property exposed to the editor or Blueprints in an Engine module.
```

This was due to the missing Category parameters of UPROPERTY variables. I added them and checked that it can be built successfully and loaded in the Unreal Editor.
